### PR TITLE
Add JDK 14 in test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,7 @@ jobs:
       script:
         - mvn verify
     - stage: test
-      jdk: openjdk12
-      script:
-        - mvn verify
-    - stage: test
-      jdk: openjdk13
+      jdk: openjdk14
       script:
         - mvn verify
 stages:


### PR DESCRIPTION
remove older non-LTS release

Signed-off-by: Aurélien Pupier <apupier@redhat.com>